### PR TITLE
Redact 'authorization' and make redaction case insensitive for everything

### DIFF
--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -1,7 +1,7 @@
 import { format } from 'winston';
 import traverse from 'traverse';
 
-const keysToRedact = [
+let keysToRedact = [
   'client_secret',
   'newPassword',
   'currentPassword',
@@ -13,9 +13,12 @@ const keysToRedact = [
   'Authorization'
 ];
 
+// makes it case insensitive
+keysToRedact = keysToRedact.map(key => key.toLowerCase());
+
 const redact = format(info => {
   const result = traverse(info).map(function redactor() {
-    if (this.key && keysToRedact.includes(this.key)) {
+    if (this.key && keysToRedact.includes(this.key.toLowerCase())) {
       this.update('[REDACTED]');
     }
   });

--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -10,7 +10,7 @@ const keysToRedact = [
   'description',
   'blurb',
   'rules',
-  'authorization'
+  'Authorization'
 ];
 
 const redact = format(info => {

--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -1,20 +1,18 @@
 import { format } from 'winston';
 import traverse from 'traverse';
 
-let keysToRedact = [
+// any values you enter here should be lowercase for it to work - it will redact regardless of case sensitivity
+const keysToRedact = [
   'client_secret',
-  'newPassword',
-  'currentPassword',
-  'stripeSecretKey',
+  'newpassword',
+  'currentpassword',
+  'stripesecretkey',
   'password',
   'description',
   'blurb',
   'rules',
-  'Authorization'
+  'authorization'
 ];
-
-// makes it case insensitive
-keysToRedact = keysToRedact.map(key => key.toLowerCase());
 
 const redact = format(info => {
   const result = traverse(info).map(function redactor() {

--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -10,9 +10,10 @@ const keysToRedact = [
   'description',
   'blurb',
   'rules',
+  'authorization'
 ];
 
-const redact = format((info) => {
+const redact = format(info => {
   const result = traverse(info).map(function redactor() {
     if (this.key && keysToRedact.includes(this.key)) {
       this.update('[REDACTED]');
@@ -23,8 +24,8 @@ const redact = format((info) => {
   const levelSym = Symbol.for('level');
   const splatSym = Symbol.for('splat');
 
-  result[levelSym] = info[levelSym as unknown as string];
-  result[splatSym] = info[splatSym as unknown as string];
+  result[levelSym] = info[(levelSym as unknown) as string];
+  result[splatSym] = info[(splatSym as unknown) as string];
 
   return result;
 });

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -23,6 +23,13 @@ describe('logger', () => {
       expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
     });
 
+    it('should redact authorization', () => {
+      logger.error('Testing redaction', {
+        header: { authorization: 'This has authorization data but we want to change this to [REDACTED]' }
+      });
+      expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+    });
+
     it('should be able to redact deeply nested keys', () => {
       // eslint-disable-next-line @typescript-eslint/camelcase
       logger.info('Testing redaction', { obj: { this: { is: { deep: { client_secret: 'hello' } } } } });
@@ -46,7 +53,7 @@ describe('logger', () => {
     describe('captureKeys', () => {
       it('postal', () => {
         const data = {
-          postal: 'B0J1V7',
+          postal: 'B0J1V7'
         };
 
         logger.info('hello world', data);
@@ -55,7 +62,7 @@ describe('logger', () => {
       });
       it('email', () => {
         const data = {
-          email: 'jamie3@gmail.com',
+          email: 'jamie3@gmail.com'
         };
 
         logger.info('hello world', data);
@@ -65,7 +72,7 @@ describe('logger', () => {
 
       it('province', () => {
         const data = {
-          province: 'AB',
+          province: 'AB'
         };
 
         logger.info('hello world', data);
@@ -75,7 +82,7 @@ describe('logger', () => {
 
       it('phone', () => {
         const data = {
-          phone: '9025551234',
+          phone: '9025551234'
         };
 
         logger.info('hello world', data);
@@ -85,7 +92,7 @@ describe('logger', () => {
 
       it('locale', () => {
         const data = {
-          locale: 'en',
+          locale: 'en'
         };
 
         logger.info('hello world', data);
@@ -97,8 +104,8 @@ describe('logger', () => {
       it('id -> organizationNumber', () => {
         const data = {
           organization: {
-            id: 1,
-          },
+            id: 1
+          }
         };
 
         logger.info('hello world', data);
@@ -109,8 +116,8 @@ describe('logger', () => {
       it('id -> organizationId', () => {
         const data = {
           organization: {
-            id: 'ee45e605-fa42-4a64-9b51-91fed9f8caae',
-          },
+            id: 'ee45e605-fa42-4a64-9b51-91fed9f8caae'
+          }
         };
 
         logger.info('hello world', data);
@@ -123,8 +130,8 @@ describe('logger', () => {
       it('uuid -> organizationId', () => {
         const data = {
           organization: {
-            uuid: 'ee45e605-fa42-4a64-9b51-91fed9f8caae',
-          },
+            uuid: 'ee45e605-fa42-4a64-9b51-91fed9f8caae'
+          }
         };
 
         logger.info('hello world', data);
@@ -139,8 +146,8 @@ describe('logger', () => {
       it('id -> orderNumber', () => {
         const data = {
           order: {
-            id: 1,
-          },
+            id: 1
+          }
         };
 
         logger.info('hello world', data);
@@ -151,8 +158,8 @@ describe('logger', () => {
       it('id -> orderId', () => {
         const data = {
           order: {
-            id: 'ee45e605-fa42-4a64-9b51-91fed9f8caae',
-          },
+            id: 'ee45e605-fa42-4a64-9b51-91fed9f8caae'
+          }
         };
 
         logger.info('hello world', data);
@@ -165,8 +172,8 @@ describe('logger', () => {
       it('uuid -> orderId', () => {
         const data = {
           order: {
-            uuid: 'ee45e605-fa42-4a64-9b51-91fed9f8caae',
-          },
+            uuid: 'ee45e605-fa42-4a64-9b51-91fed9f8caae'
+          }
         };
 
         logger.info('hello world', data);
@@ -179,8 +186,8 @@ describe('logger', () => {
       it('email -> email', () => {
         const data = {
           order: {
-            email: 'bob@villa.com',
-          },
+            email: 'bob@villa.com'
+          }
         };
 
         logger.info('hello world', data);
@@ -191,8 +198,8 @@ describe('logger', () => {
       it('province -> province', () => {
         const data = {
           order: {
-            province: 'BC',
-          },
+            province: 'BC'
+          }
         };
 
         logger.info('hello world', data);
@@ -203,8 +210,8 @@ describe('logger', () => {
       it('state -> province', () => {
         const data = {
           order: {
-            state: 'AB',
-          },
+            state: 'AB'
+          }
         };
 
         logger.info('hello world', data);
@@ -215,8 +222,8 @@ describe('logger', () => {
       it('provinceState -> province', () => {
         const data = {
           order: {
-            provinceState: 'NS',
-          },
+            provinceState: 'NS'
+          }
         };
 
         logger.info('hello world', data);
@@ -227,8 +234,8 @@ describe('logger', () => {
       it('referenceId -> orderReferenceId', () => {
         const data = {
           order: {
-            referenceId: 'abc',
-          },
+            referenceId: 'abc'
+          }
         };
 
         logger.info('hello world', data);
@@ -241,8 +248,8 @@ describe('logger', () => {
       it('serialNumber -> deviceSerialNumber', () => {
         const data = {
           device: {
-            serialNumber: '123456789',
-          },
+            serialNumber: '123456789'
+          }
         };
 
         logger.info('hello world', data);
@@ -255,8 +262,8 @@ describe('logger', () => {
       it('id -> eventNumber', () => {
         const data = {
           event: {
-            id: 1,
-          },
+            id: 1
+          }
         };
 
         logger.info('hello world', data);
@@ -267,8 +274,8 @@ describe('logger', () => {
       it('id -> eventId', () => {
         const data = {
           event: {
-            id: 'b21a61f6-6fff-4991-a03a-d12d04936ab5',
-          },
+            id: 'b21a61f6-6fff-4991-a03a-d12d04936ab5'
+          }
         };
 
         logger.info('hello world', data);
@@ -281,8 +288,8 @@ describe('logger', () => {
       it('uuid -> eventId', () => {
         const data = {
           event: {
-            uuid: 'b21a61f6-6fff-4991-a03a-d12d04936ab5',
-          },
+            uuid: 'b21a61f6-6fff-4991-a03a-d12d04936ab5'
+          }
         };
 
         logger.info('hello world', data);

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -23,10 +23,13 @@ describe('logger', () => {
       expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
     });
 
-    it('should redact authorization', () => {
-      logger.error('Testing redaction', {
-        header: { authorization: 'This has authorization data but we want to change this to [REDACTED]' }
+    it('should redact Authorization', () => {
+      logger.info('Testing redaction', {
+        obj: {
+          Authorization: 'Authorization Data'
+        }
       });
+      expect(process.stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('Authorization Data'));
       expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
     });
 

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -33,6 +33,16 @@ describe('logger', () => {
       expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
     });
 
+    it('should be able to redact regardless of case sensitivity', () => {
+      logger.info('Testing redaction', {
+        obj: {
+          aUtHoRiZaTiOn: 'Authorization Data'
+        }
+      });
+      expect(process.stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('Authorization Data'));
+      expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'));
+    });
+
     it('should be able to redact deeply nested keys', () => {
       // eslint-disable-next-line @typescript-eslint/camelcase
       logger.info('Testing redaction', { obj: { this: { is: { deep: { client_secret: 'hello' } } } } });


### PR DESCRIPTION
- add 'authorization' to the list of redacted keys.
  - Logging authorization details is a potential security issue.
- make redaction case insensitive for all keys.