### PR TITLE
Allow higher node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafflebox-technologies-inc/rafflebox-logger",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Standard JSON logger for Node services",
   "author": "Rafflebox Engineering",
   "main": "index.js",
@@ -12,7 +12,7 @@
     "url": "git://github.com/rafflebox-technologies-inc/rafflebox-logger.git"
   },
   "engines": {
-    "node": "^14 || ^16"
+    "node": ">=14"
   },
   "scripts": {
     "clean": "rm -rf build",


### PR DESCRIPTION
Attempting to have api v3 be node 18. This package was limiting to 14 or 16.
I have changed it to greater than 14, it works locally.