### PR TITLE
Add request-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rafflebox-technologies-inc/rafflebox-logger",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Standard JSON logger for Node services",
   "author": "Rafflebox Engineering",
   "main": "index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Logger from './logger';
+import { requestLogger } from './request-logger';
 
 const logger = new Logger();
 
 export default logger;
-export { Logger };
+export { Logger, requestLogger };

--- a/src/request-logger.ts
+++ b/src/request-logger.ts
@@ -19,12 +19,12 @@ export interface Response {
 type NextFunction = (err?: unknown) => void;
 
 const getIpAddress = (req: Request): string | undefined => {
-  const ipAddress = req.get('x-forwarded-for') || req.socket.remoteAddress;
+  const ipAddress = req.get('x-forwarded-for') ?? req.socket.remoteAddress;
 
   return ipAddress?.replace('::ffff:', '');
 };
 
-const redact = (redactFields: string[], input?: unknown): unknown | undefined => {
+const redact = (redactFields: string[], input?: unknown): unknown => {
   if (!input) {
     return input;
   }

--- a/src/request-logger.ts
+++ b/src/request-logger.ts
@@ -1,0 +1,80 @@
+import Logger from './logger';
+
+// These interfaces are a partial definition of express. This is to avoid a dependency on express.
+export interface Request {
+  method: string;
+  body: unknown;
+  headers: unknown;
+  originalUrl?: string;
+  get: (key: string) => string | undefined;
+  socket: {
+    remoteAddress?: string;
+  };
+}
+
+export interface Response {
+  locals: Record<string, unknown>;
+}
+
+type NextFunction = (err?: unknown) => void;
+
+const getIpAddress = (req: Request): string | undefined => {
+  const ipAddress = req.get('x-forwarded-for') || req.socket.remoteAddress;
+
+  return ipAddress?.replace('::ffff:', '');
+};
+
+const redact = (redactFields: string[], input?: unknown): unknown | undefined => {
+  if (!input) {
+    return input;
+  }
+
+  const upperRedactFields = redactFields.map(field => field.toUpperCase());
+
+  // deep clone object
+  const object = JSON.parse(JSON.stringify(input));
+
+  Object.keys(object).forEach(key => {
+    if (upperRedactFields.includes(key.toUpperCase())) {
+      object[key] = '[REDACTED]';
+    } else if (typeof key === 'object') {
+      redact(object.key);
+    }
+  });
+
+  return object;
+};
+
+export const requestLogger = <Req extends Request, Res extends Response>(config: {
+  logger: Logger;
+  contextExtractor: (req: Req, res: Res) => Record<string, unknown>;
+  redactFields: string[];
+  logHTTPMethods: string[];
+  loggingExemptRoutePatterns: string[];
+}): ((req: Req, res: Res, next: NextFunction) => void) => {
+  const { logger, redactFields, logHTTPMethods, loggingExemptRoutePatterns, contextExtractor } = config;
+
+  return (req: Req, res: Res, next: NextFunction): void => {
+    try {
+      if (
+        logHTTPMethods.includes(req.method) &&
+        !loggingExemptRoutePatterns.find(pattern => req.originalUrl?.includes(pattern))
+      ) {
+        const context = contextExtractor(req, res);
+
+        logger.info(`request-logger - ${req.method} ${req.originalUrl}`, {
+          body: redact(redactFields, req.body),
+          headers: redact(redactFields, req.headers),
+          caller: {
+            ipAddress: getIpAddress(req),
+            ...context
+          }
+        });
+      }
+    } catch (error) {
+      logger.error('request-logger - Error logging request', { error });
+    }
+
+    next();
+  };
+};

--- a/src/request-logger.ts
+++ b/src/request-logger.ts
@@ -1,6 +1,6 @@
 import Logger from './logger';
 
-// These interfaces are a partial definition of express. This is to avoid a dependency on express.
+// These interfaces are a partial definitions of express. This is to avoid a dependency on express.
 export interface Request {
   method: string;
   body: unknown;
@@ -47,12 +47,12 @@ const redact = (redactFields: string[], input?: unknown): unknown | undefined =>
 
 export const requestLogger = <Req extends Request, Res extends Response>(config: {
   logger: Logger;
-  contextExtractor: (req: Req, res: Res) => Record<string, unknown>;
+  extractContext: (req: Req, res: Res) => Record<string, unknown>;
   redactFields: string[];
   logHTTPMethods: string[];
   loggingExemptRoutePatterns: string[];
 }): ((req: Req, res: Res, next: NextFunction) => void) => {
-  const { logger, redactFields, logHTTPMethods, loggingExemptRoutePatterns, contextExtractor } = config;
+  const { logger, redactFields, logHTTPMethods, loggingExemptRoutePatterns, extractContext } = config;
 
   return (req: Req, res: Res, next: NextFunction): void => {
     try {
@@ -60,7 +60,7 @@ export const requestLogger = <Req extends Request, Res extends Response>(config:
         logHTTPMethods.includes(req.method) &&
         !loggingExemptRoutePatterns.find(pattern => req.originalUrl?.includes(pattern))
       ) {
-        const context = contextExtractor(req, res);
+        const context = extractContext(req, res);
 
         logger.info(`request-logger - ${req.method} ${req.originalUrl}`, {
           body: redact(redactFields, req.body),

--- a/test/request-logger.spec.ts
+++ b/test/request-logger.spec.ts
@@ -1,0 +1,115 @@
+import logger from '../src';
+
+import { requestLogger, Request, Response } from '../src/request-logger';
+
+describe('request-logger', () => {
+  let req: Request;
+  let res: Response;
+  let next = jest.fn();
+
+  beforeEach(() => {
+    req = {
+      body: {},
+      get: jest.fn(),
+      originalUrl: 'original-url',
+      headers: {
+        'rb-client': 'TEST'
+      },
+      method: 'POST',
+      socket: {
+        remoteAddress: 'remote-address'
+      }
+    };
+
+    res = {
+      locals: {}
+    };
+
+    next = jest.fn();
+
+    jest.spyOn(logger, 'info').mockReturnValue();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should not log if request method is not enabled', () => {
+    req.method = 'Not method';
+
+    requestLogger({
+      contextExtractor: () => ({}),
+      logger,
+      loggingExemptRoutePatterns: [],
+      logHTTPMethods: ['POST'],
+      redactFields: []
+    })(req, res, next);
+
+    expect(logger.info).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not log if request url is exempt', () => {
+    req.originalUrl = '/testing-stuff';
+
+    requestLogger({
+      contextExtractor: () => ({}),
+      logger,
+      loggingExemptRoutePatterns: ['/testing-stuff'],
+      logHTTPMethods: ['POST'],
+      redactFields: []
+    })(req, res, next);
+
+    expect(logger.info).toHaveBeenCalledTimes(0);
+  });
+
+  it('should redact headers and body', () => {
+    req.body = {
+      password: 'My Password'
+    };
+
+    req.headers = { 'rb-client': 'TEST', Authorization: 'My token' };
+
+    requestLogger({
+      contextExtractor: () => ({}),
+      logger,
+      loggingExemptRoutePatterns: [],
+      logHTTPMethods: ['POST'],
+      redactFields: ['password', 'authorization']
+    })(req, res, next);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(`request-logger - POST original-url`, {
+      body: {
+        password: '[REDACTED]'
+      },
+      headers: {
+        'rb-client': 'TEST',
+        Authorization: '[REDACTED]'
+      },
+      caller: {
+        ipAddress: 'remote-address'
+      }
+    });
+  });
+
+  it('should include the results of the contextExtractor in the caller info', () => {
+    requestLogger({
+      contextExtractor: () => ({ testing: 'test' }),
+      logger,
+      loggingExemptRoutePatterns: [],
+      logHTTPMethods: ['POST'],
+      redactFields: []
+    })(req, res, next);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      `request-logger - POST original-url`,
+      expect.objectContaining({
+        caller: {
+          ipAddress: 'remote-address',
+          testing: 'test'
+        }
+      })
+    );
+  });
+});

--- a/test/request-logger.spec.ts
+++ b/test/request-logger.spec.ts
@@ -38,7 +38,7 @@ describe('request-logger', () => {
     req.method = 'Not method';
 
     requestLogger({
-      contextExtractor: () => ({}),
+      extractContext: () => ({}),
       logger,
       loggingExemptRoutePatterns: [],
       logHTTPMethods: ['POST'],
@@ -52,7 +52,7 @@ describe('request-logger', () => {
     req.originalUrl = '/testing-stuff';
 
     requestLogger({
-      contextExtractor: () => ({}),
+      extractContext: () => ({}),
       logger,
       loggingExemptRoutePatterns: ['/testing-stuff'],
       logHTTPMethods: ['POST'],
@@ -70,7 +70,7 @@ describe('request-logger', () => {
     req.headers = { 'rb-client': 'TEST', Authorization: 'My token' };
 
     requestLogger({
-      contextExtractor: () => ({}),
+      extractContext: () => ({}),
       logger,
       loggingExemptRoutePatterns: [],
       logHTTPMethods: ['POST'],
@@ -94,7 +94,7 @@ describe('request-logger', () => {
 
   it('should include the results of the contextExtractor in the caller info', () => {
     requestLogger({
-      contextExtractor: () => ({ testing: 'test' }),
+      extractContext: () => ({ testing: 'test' }),
       logger,
       loggingExemptRoutePatterns: [],
       logHTTPMethods: ['POST'],


### PR DESCRIPTION
- Add request logger. This code is based on the request logger currently in use in both api and payment api. I was about to copy it to api-v3, Instead I extracted it out into a reusable form here.